### PR TITLE
Enable short term memory

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -222,8 +222,8 @@ const controls:HTMLControlList = {
     },
     "tempo": {
         htmlInput: (<HTMLInputElement>document.getElementById("Tempo")),
-        min: 40,
-        max: 80
+        min: 20,
+        max: 180
     },
     // "Toggles"
     "autoplay": {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -27,7 +27,6 @@ const lfoWaveTypes:string[] = [
 let circles:HTMLSpanElement[] = [];
 // used to keep track of recently played melodies and chords
 let shortTermMemory:Note[][] = [];
-
 const twelfthRootOfTwo:number = Math.pow(2, 1/12); // need this to calculate Hz based on interval & scale
 
 /* array representing intervals from the root tone.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -25,6 +25,8 @@ const lfoWaveTypes:string[] = [
 
 // used to keep track of circles which represent notes
 let circles:HTMLSpanElement[] = [];
+// used to keep track of recently played melodies and chords
+let shortTermMemory:Note[][] = [];
 
 const twelfthRootOfTwo:number = Math.pow(2, 1/12); // need this to calculate Hz based on interval & scale
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -63,7 +63,7 @@ const maybe = (condition: any, defaultCondition: any = null, weight = 50) => {
  * the array.
  * @param array
  */
-const getRandomArrayItem = (array:any[]) => array[Math.floor(Math.random()*array.length)];
+const getRandomArrayItem = (array:any[]) => array[Math.round(getRange(0, array.length - 1))];
 
 /**
  * Gives back a number in the range provided.

--- a/src/web-audio.ts
+++ b/src/web-audio.ts
@@ -330,13 +330,13 @@ function searchMemoryForPhrase(event: MouseEvent) {
     if (DEBUG) console.info("========================================");
     let overrideX: number;
     // get a note array from 
-    const memoryIndex = Math.floor(getRange(0, shortTermMemory.length - 1));
+    const memoryIndex = Math.round(getRange(0, shortTermMemory.length - 1));
     const rememberedPhrase = shortTermMemory[memoryIndex];
     rememberedPhrase.forEach((note) => {
         overrideX = setClickPositionFromNoteFrequency(note, event);
         playAndShowNote(note, {event, overrideX} as CustomMouseEvent);
     });
-    if(maybe(true)) {
+    if(maybe(true, false, 66)) {
         if (DEBUG) console.info("COMPOSER removing the phrase from memory");
         shortTermMemory.splice(memoryIndex, 1);
         if (DEBUG) console.info(shortTermMemory);

--- a/src/web-audio.ts
+++ b/src/web-audio.ts
@@ -410,16 +410,15 @@ function buildChordFromNote(note: Note, event: MouseEvent) {
     if (DEBUG) console.info("the chord will be " + additionalChordTones + " notes");
     if (DEBUG) console.info("========================================");
     // then for every other frequency in our chord...
-    const chordIntervals = getChord(note, additionalChordTones);
-    for(let chordIndex = 0; chordIndex < chordIntervals.length; chordIndex++) {
+    getChord(note, additionalChordTones).forEach((chordTone) => {
         chordNote = note;
-        chordNote.frequency = chordIntervals[chordIndex];
+        chordNote.frequency = chordTone;
         // handle x & y seperately for chord notes, because
         // the x-axis will need to be calculated
         overrideX = setClickPositionFromNoteFrequency(chordNote, event);
-        rememberedPhrase.push(chordNote);
+        rememberedPhrase.push({...chordNote}); // push a new copy of chordNote so it doesn't get overwritten
         playAndShowNote(chordNote, {event, overrideX} as CustomMouseEvent);
-    }
+    });
     attemptToRememberPhrase(rememberedPhrase);
 }
 
@@ -472,8 +471,7 @@ function buildMelodyFromNote(note: Note, event: MouseEvent) {
     // play the initial tone first...
     playAndShowNote(note, {event} as CustomMouseEvent);
     // for every frequency in our melody...
-    const melodyIntervals = getMelody(note, additionalMelodyTones);
-    for(let melodyIndex = 0; melodyIndex < melodyIntervals.length; melodyIndex++) {
+    getMelody(note, additionalMelodyTones).forEach((chordTone) => {
         // get a new note length
         let currentNoteLength = getMelodyNoteDuration();
         // copy the "base note"
@@ -481,16 +479,16 @@ function buildMelodyFromNote(note: Note, event: MouseEvent) {
         // use our new note length
         chordNote.time = currentNoteLength;
         // set the frequency to what getMelody() advises
-        chordNote.frequency = melodyIntervals[melodyIndex];
+        chordNote.frequency = chordTone;
         // apply then compound the delay to ensure space between notes
         chordNote.delay = currentNoteDelay;
         currentNoteDelay += currentNoteLength;
         // handle x & y seperately for chord notes, because
         // the x-axis will need to be calculated
         overrideX = setClickPositionFromNoteFrequency(chordNote, event);
-        rememberedPhrase.push(chordNote);
+        rememberedPhrase.push({...chordNote}); // push a new copy of chordNote so it doesn't get overwritten
         playAndShowNote(chordNote, {event, overrideX} as CustomMouseEvent);
-    }
+    });
     attemptToRememberPhrase(rememberedPhrase);
 }
 

--- a/src/web-audio.ts
+++ b/src/web-audio.ts
@@ -329,12 +329,11 @@ function searchMemoryForPhrase(event: MouseEvent) {
     if (DEBUG) console.info("searching short term memory for a phrase");
     if (DEBUG) console.info("========================================");
     let overrideX: number;
-    // get a note array from 
     const memoryIndex = Math.round(getRange(0, shortTermMemory.length - 1));
     const rememberedPhrase = shortTermMemory[memoryIndex];
-    rememberedPhrase.forEach((note) => {
-        overrideX = setClickPositionFromNoteFrequency(note, event);
-        playAndShowNote(note, {event, overrideX} as CustomMouseEvent);
+    rememberedPhrase.forEach((rememberedNote) => {
+        overrideX = setClickPositionFromNoteFrequency(rememberedNote, event);
+        playAndShowNote(rememberedNote, {event, overrideX} as CustomMouseEvent);
     });
     if(maybe(true, false, 66)) {
         if (DEBUG) console.info("COMPOSER removing the phrase from memory");
@@ -384,6 +383,7 @@ function buildChordFromNote(note: Note, event: MouseEvent) {
     if (DEBUG) console.info("creating a chord");
     let chordNote: Note;
     let overrideX: number;
+    // we'll attempt to remember this chord
     let rememberedPhrase: Note[] = [];
     /* Our chord should have at last 2 tones, and at maximum 4 tones, unless
      * our scale doesn't have 4 tones, then just use as many as possible. */
@@ -392,12 +392,11 @@ function buildChordFromNote(note: Note, event: MouseEvent) {
     if (DEBUG) console.info("========================================");
     // then for every other frequency in our chord...
     getChord(note, additionalChordTones).forEach((chordTone) => {
-        chordNote = note;
+        // copy the "base note"
+        chordNote = {...note}; // push a new copy of chordNote so it doesn't get overwritten
         chordNote.frequency = chordTone;
-        // handle x & y seperately for chord notes, because
-        // the x-axis will need to be calculated
+        rememberedPhrase.push(chordNote);
         overrideX = setClickPositionFromNoteFrequency(chordNote, event);
-        rememberedPhrase.push({...chordNote}); // push a new copy of chordNote so it doesn't get overwritten
         playAndShowNote(chordNote, {event, overrideX} as CustomMouseEvent);
     });
     attemptToRememberPhrase(rememberedPhrase);
@@ -426,8 +425,6 @@ function buildArpeggioFromNote(note: Note, event: MouseEvent) {
         // compound delay
         previousDelay += previousDelay;
         chordNote.delay = previousDelay;
-        // handle x & y seperately for chord notes, because
-        // the x-axis will need to be calculated
         overrideX = setClickPositionFromNoteFrequency(chordNote, event);
         playAndShowNote(chordNote, {event, overrideX} as CustomMouseEvent);
     });
@@ -440,8 +437,9 @@ function buildArpeggioFromNote(note: Note, event: MouseEvent) {
  */
 function buildMelodyFromNote(note: Note, event: MouseEvent) {
     if (DEBUG) console.info("creating a melody");
-    let chordNote: Note;
+    let melodyNote: Note;
     let overrideX: number;
+    // we'll attempt to remember this melody
     let rememberedPhrase: Note[] = [note];
     /* Our melody should have at last 4 tones, and at maximum 8 tones, unless
      * our scale doesn't have 8 tones, then just use as many as possible. */
@@ -452,23 +450,21 @@ function buildMelodyFromNote(note: Note, event: MouseEvent) {
     // play the initial tone first...
     playAndShowNote(note, {event} as CustomMouseEvent);
     // for every frequency in our melody...
-    getMelody(note, additionalMelodyTones).forEach((chordTone) => {
+    getMelody(note, additionalMelodyTones).forEach((melodyTone) => {
         // get a new note length
         let currentNoteLength = getMelodyNoteDuration();
         // copy the "base note"
-        chordNote = {...note}; // push a new copy of chordNote so it doesn't get overwritten
+        melodyNote = {...note}; // push a new copy of melodyNote so it doesn't get overwritten
         // use our new note length
-        chordNote.time = currentNoteLength;
+        melodyNote.time = currentNoteLength;
         // set the frequency to what getMelody() advises
-        chordNote.frequency = chordTone;
+        melodyNote.frequency = melodyTone;
         // apply then compound the delay to ensure space between notes
-        chordNote.delay = currentNoteDelay;
+        melodyNote.delay = currentNoteDelay;
         currentNoteDelay += currentNoteLength;
-        // handle x & y seperately for chord notes, because
-        // the x-axis will need to be calculated
-        overrideX = setClickPositionFromNoteFrequency(chordNote, event);
-        rememberedPhrase.push(chordNote);
-        playAndShowNote(chordNote, {event, overrideX} as CustomMouseEvent);
+        rememberedPhrase.push(melodyNote);
+        overrideX = setClickPositionFromNoteFrequency(melodyNote, event);
+        playAndShowNote(melodyNote, {event, overrideX} as CustomMouseEvent);
     });
     attemptToRememberPhrase(rememberedPhrase);
 }


### PR DESCRIPTION
## Description
Need to be able to recognize melodies and chords when you listen to midio.

Note: Still have a bug where memories only take the last note's values... I suspect it has something to do with the for loop where melodies and chords are being constructed.

## Related Issue/Motivation/Context
https://github.com/evangipson/midio/issues/22

## How Has This Been Tested?
I let midio run for awhile and never had more than 5 phrases remembered at any time. I still need to test how frequent the melodies and chords are, and if 5 is even a good limit on melodies to remember. maybe more or maybe less! still have to listen more.

Update: listened a bunch, adjusted the max and min of tempo a bit and I think it's sounding much more recognizable, so gonna merge.

## Screenshots
none